### PR TITLE
fix: opening file edgecases

### DIFF
--- a/lua/omni-preview/commands.lua
+++ b/lua/omni-preview/commands.lua
@@ -45,7 +45,7 @@ end
 
 function M.start()
     local ft = vim.bo.filetype
-    local fe = vim.fn.expand("%:e")
+    local fe = vim.fn.expand("%:e"):lower()
     local pr = require("omni-preview").previews
     local trig = false
     local current_buf = vim.api.nvim_get_current_buf()
@@ -71,7 +71,7 @@ function M.start()
                 return
             else
                 vim.notify(
-                    "Invalid preview command for filetype: " .. ft,
+                    "Invalid preview command for filetype: " .. fe,
                     vim.log.levels.ERROR
                 )
                 return
@@ -80,7 +80,7 @@ function M.start()
     end
 
     vim.notify(
-        "No preview available for filetype: " .. ft,
+        "No preview available for filetype: " .. fe,
         vim.log.levels.WARN
     )
 end

--- a/lua/omni-preview/defaults.lua
+++ b/lua/omni-preview/defaults.lua
@@ -3,7 +3,7 @@ local M = {}
 
 M.system_open = function()
     local filename = vim.fn.expand("%:p")
-    local success = os.execute("open " .. filename)
+    local success = os.execute("open " .. vim.fn.shellescape(filename))
     if not success then
         print("Could not use system command \"open\" to open " .. filename)
     end


### PR DESCRIPTION
2 fixes:

- Currently `M.system_open` will blow up if file names have spaces. This adds escaping to the file names on open
- Opening files with capitalized exts(eg picture.JPG) was breaking. Lower before compare