### PR TITLE
feat: add cloak.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://github.com/user-attachments/assets/e9c0a587-0536-478d-b408-30422ac8e73b
 - [x] Latex (just by finding a corresponding pdf file, look into vimtex for more)
 - [x] Markdown
 - [x] Typst
+- [x] Env Files
 - [ ] ...More coming soon
 
 ## Install
@@ -167,6 +168,11 @@ require("omni-preview").setup({
 })
 ```
 
+- [cloak.nvim](https://github.com/laytan/cloak.nvim) cloak sensitive data
+
+```lua
+    {'laytan/cloak.nvim', lazy = true}
+```
 
 
 #### ROADMAP 🌾

--- a/lua/omni-preview/defaults.lua
+++ b/lua/omni-preview/defaults.lua
@@ -73,6 +73,31 @@ M.previews = {
         start = function() require "peek".open() end,
         stop = function() require "peek".close() end,
     },
+    {
+        name = "cloak",
+        trig = function()
+          local cloak = require "cloak"
+          local patterns = cloak.opts.patterns
+          -- get file_patterns config straight from cloak
+          local file_patterns = patterns[1].file_pattern
+          -- can be string or table of strings
+          if type(file_patterns) == 'string' then
+            file_patterns = { file_patterns }
+          end
+          -- get current buffer filename without path
+          local base_name = vim.fn.expand("%:t")
+          for _, file_pattern in ipairs(file_patterns) do
+            if base_name ~= nil and
+                vim.fn.match(base_name, vim.fn.glob2regpat(file_pattern)) ~= -1 then
+              return true
+            end
+          end
+
+          return false
+        end,
+        start = function() require "cloak".enable() end,
+        stop = function() require "cloak".disable() end,
+    },
     { trig = "pdf",  start = M.system_open, name = "builtin" },
     { trig = "svg",  start = M.system_open, name = "builtin" },
     { trig = "png",  start = M.system_open, name = "builtin" },


### PR DESCRIPTION
[cloak.nvim](https://github.com/laytan/cloak.nvim) feels like a nice addition to this plugin

This trigger is a custom function that will use what the user defines for the file_pattern that they want cloaked in their cloak config.

Tested with cloak.nvim as dependency of omni-preview
Tested with file_patterns for cloak as table
```lua
              file_pattern = { ".env*", ".npmrc*", "local.cjs*", "credentials*" },
```
Tested with file_patterns for cloak as string
```lua
              file_pattern = ".env*",
```