### PR TITLE
feat!: UI select

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,14 @@ Sometimes these plugins have behavior that you want to change, simply call setup
 One command to rule them all
 `:OmniPreview {args}`
 
-Three intuitive subcommands
-`:OmniPreview start`, `:OmniPreview stop`, `:OmniPreview toggle`. 
+Two intuitive subcommands
+`:OmniPreview start`, `:OmniPreview stop`. 
 
-There is no default keymapping for the, I recommend setting: 
+There is no default keymapping, I recommend setting: 
 
 ```lua
-vim.keymap.set("n", "<leader>p", ":OmniPreview toggle<CR>", { silent = true })
+vim.keymap.set("n", "<leader>po", ":OmniPreview start<CR>", { silent = true })
+vim.keymap.set("n", "<leader>pc", ":OmniPreview stop<CR>", { silent = true })
 ```
 
 I often just close the preview manually since some of them don't have defined stop behavior, for instance system level preview tools. Maybe there is some way to close these efficiently but I'm not all that aware of it.    
@@ -186,7 +187,7 @@ require("omni-preview").setup({
 #### ROADMAP 🌾
 Lot's of work to do, this is early days. 
 - [ ] Mason like UI and registry
-- [ ] Telescope like picker to support multiple types of previews
+- [x] Telescope like picker to support multiple types of previews
 - [ ] More config options for more plugins
 - [ ] More coverage of LaTeX 
 - [ ] Support for multiple previews on a single filetype

--- a/lua/omni-preview/commands.lua
+++ b/lua/omni-preview/commands.lua
@@ -12,7 +12,7 @@ M.stop = function()
 
     -- Only pop ui if there are multiple options
     if #useable_previews > 1 then
-      ui.create_float_window(useable_previews, defaults.stop_preview)
+      ui.create_float_window(useable_previews, "Stop Preview", defaults.stop_preview)
     else
       defaults.stop_preview(useable_previews[1])
     end
@@ -27,7 +27,7 @@ M.start = function()
 
     -- Only pop ui if there are multiple options
     if #useable_previews > 1 then
-      ui.create_float_window(useable_previews, defaults.start_preview)
+      ui.create_float_window(useable_previews, "Start Preview", defaults.start_preview)
     else
       defaults.start_preview(useable_previews[1])
     end

--- a/lua/omni-preview/commands.lua
+++ b/lua/omni-preview/commands.lua
@@ -1,43 +1,24 @@
 local defaults = require("omni-preview.defaults")
+local ui = require("omni-preview.ui")
 
 local M = {}
 
-M.stop = function(debug)
-    local debug = debug or false
-    local rp = defaults.find_running_preview()
+M.stop = function()
+    local running_plugins = defaults.find_running_previews()
 
-    if not rp and debug then
-        vim.notify(
-            "No running preview found",
-            vim.log.levels.WARN
-        )
+    if not running_plugins then
         return
     end
 
-    if not rp then
-      return
-    end
-
-    local key = rp.key
-
-    if rp.preview.stop == nil and debug then
-        vim.notify(
-            "Failed to stop running preview, no command provided",
-            vim.log.levels.ERROR
-        )
-        return
-    end
-
-    rp.preview.running[key] = nil
-    if type(rp.preview.stop) == "string" then
-        vim.cmd(rp.preview.stop)
-    elseif type(rp.preview.stop) == "function" then
-        rp.preview.stop()
+    if #running_plugins > 1 then
+      ui.create_float_window(running_plugins)
+    else
+      defaults.stop_preview(running_plugins[1])
     end
 end
 
 M.toggle = function()
-    local rp = defaults.find_running_preview()
+    local rp = defaults.find_running_previews()
 
     if not rp then
         M.start()
@@ -46,39 +27,18 @@ M.toggle = function()
     end
 end
 
-function M.start()
-    local key = nil
-    local current_buf = vim.api.nvim_get_current_buf()
-    local p = defaults.get_triggerable_preview()
-  
-    if p then
-        key = p.global and p.name or current_buf
-    
-        if type(p.start) == "string" then
-            vim.cmd(p.start)
-            if p.running then
-              p.running[key] = true
-            end
-            return
-        elseif type(p.start) == "function" then
-            p.start()
-            if p.running then
-              p.running[key] = true
-            end
-            return
-        else
-            vim.notify(
-                "Invalid preview command for current filetype",
-                vim.log.levels.ERROR
-            )
-            return
-        end
+M.start = function()
+    local useable_previews = defaults.get_triggerable_previews()
+
+    if not useable_previews then
+        return
     end
 
-    vim.notify(
-        "No preview available for current filetype",
-        vim.log.levels.WARN
-    )
+    if #useable_previews > 1 then
+      ui.create_float_window(useable_previews)
+    else
+      defaults.start_preview(useable_previews[1])
+    end
 end
 
 return M

--- a/lua/omni-preview/commands.lua
+++ b/lua/omni-preview/commands.lua
@@ -4,26 +4,17 @@ local ui = require("omni-preview.ui")
 local M = {}
 
 M.stop = function()
-    local running_plugins = defaults.find_running_previews()
+    local useable_previews = defaults.get_triggerable_previews()
 
-    if not running_plugins then
+    if not useable_previews then
         return
     end
 
-    if #running_plugins > 1 then
-      ui.create_float_window(running_plugins)
+    -- Only pop ui if there are multiple options
+    if #useable_previews > 1 then
+      ui.create_float_window(useable_previews, defaults.stop_preview)
     else
-      defaults.stop_preview(running_plugins[1])
-    end
-end
-
-M.toggle = function()
-    local rp = defaults.find_running_previews()
-
-    if not rp then
-        M.start()
-    else
-        M.stop()
+      defaults.stop_preview(useable_previews[1])
     end
 end
 
@@ -34,8 +25,9 @@ M.start = function()
         return
     end
 
+    -- Only pop ui if there are multiple options
     if #useable_previews > 1 then
-      ui.create_float_window(useable_previews)
+      ui.create_float_window(useable_previews, defaults.start_preview)
     else
       defaults.start_preview(useable_previews[1])
     end

--- a/lua/omni-preview/init.lua
+++ b/lua/omni-preview/init.lua
@@ -6,7 +6,7 @@ M.command = function(opts)
     if commands[sub] then
         commands[sub](opts)
     else
-        print("Invalid subcommand" .. sub)
+        print("Invalid subcommand " .. sub)
     end
 end
 

--- a/lua/omni-preview/ui.lua
+++ b/lua/omni-preview/ui.lua
@@ -1,0 +1,69 @@
+local defaults = require("omni-preview.defaults")
+
+---@class CustomModule
+local M = {}
+
+M.close_float = function(buf, win)
+  if buf ~= nil and vim.api.nvim_buf_is_valid(buf) then
+    vim.api.nvim_buf_delete(buf, { force = true })
+  end
+
+  if win ~= nil and vim.api.nvim_win_is_valid(win) then
+    vim.api.nvim_win_close(win, true)
+  end
+end
+
+M.create_float_window = function(previews)
+  -- Create a scratch buffer
+  local buf = vim.api.nvim_create_buf(false, true)
+
+  -- create array of just names for the float
+  local names = vim.tbl_map(function(item)
+    return item.name
+  end, previews)
+
+  -- Insert the lines into the buffer
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, names)
+
+  -- Open the buffer in a floating window for display
+  local width = 50
+  local height = 10
+  local float = vim.api.nvim_open_win(buf, true, {
+    relative = "editor",
+    width = width,
+    height = height,
+    row = (vim.o.lines - height) / 2,
+    col = (vim.o.columns - width) / 2,
+    style = "minimal",
+    border = "rounded",
+  })
+
+  -- line numbers
+  vim.api.nvim_set_option_value("number", true, { win = float })
+
+  -- Set bindings for menu
+  vim.keymap.set("n", "<ESC>", function()
+    M.close_float(buf, float)
+  end, { buffer = buf, silent = true })
+
+  vim.keymap.set("n", "q", function()
+    M.close_float(buf, float)
+  end, { buffer = buf, silent = true })
+
+  vim.keymap.set("n", "<CR>", function()
+    -- Get cursor line number while in the float window
+    local line_number = vim.api.nvim_win_get_cursor(0)[1]
+
+    -- get the name(text on the line)
+    local preview_name = vim.api.nvim_buf_get_lines(buf, line_number - 1, line_number, false)[1]
+
+    local p = defaults.find_preview_by_name(preview_name)
+
+    M.close_float(buf, float)
+
+    -- start AFTER closing picker or it will use wrong buf
+    defaults.start_preview(p)
+  end, { buffer = buf, silent = true })
+end
+
+return M

--- a/lua/omni-preview/ui.lua
+++ b/lua/omni-preview/ui.lua
@@ -13,7 +13,7 @@ M.close_float = function(buf, win)
   end
 end
 
-M.create_float_window = function(previews, callback)
+M.create_float_window = function(previews, title, callback)
   -- Create a scratch buffer
   local buf = vim.api.nvim_create_buf(false, true)
 
@@ -36,6 +36,8 @@ M.create_float_window = function(previews, callback)
     col = (vim.o.columns - width) / 2,
     style = "minimal",
     border = "rounded",
+    title = title,
+    title_pos = 'center'
   })
 
   -- line numbers

--- a/lua/omni-preview/ui.lua
+++ b/lua/omni-preview/ui.lua
@@ -13,7 +13,7 @@ M.close_float = function(buf, win)
   end
 end
 
-M.create_float_window = function(previews)
+M.create_float_window = function(previews, callback)
   -- Create a scratch buffer
   local buf = vim.api.nvim_create_buf(false, true)
 
@@ -61,8 +61,10 @@ M.create_float_window = function(previews)
 
     M.close_float(buf, float)
 
-    -- start AFTER closing picker or it will use wrong buf
-    defaults.start_preview(p)
+    -- start/close AFTER closing picker or it will use wrong buf
+    -- callback that will start or close the preview
+    -- this can be whatever function that needs to be passed in to do something
+    callback(p)
   end, { buffer = buf, silent = true })
 end
 


### PR DESCRIPTION
This adds a UI selector for filetypes with multiple plugins installed that can be enabled

This is _kinda_ an overhaul on how this plugin would handle states

This is a BREAKING change as it removes the toggle command

This removes tracking running previews and removes the `toggle` command. If we want have this plugin work with more and more plugins and be able to use a UI picker more easily, tracking state of plugins running is going to be overly complex IMO. Plugins can be active at start, active based on commands running, active based on filetype opening, etc. This feels like too much to handle ATM. Depending on how users use certain plugins it could not work nicely with omni preview.

This refactor relinquishes that control and just leaves it in the hands of the user to know which plugin they want to start/stop. No running preview tracking(which means no toggling).

The default commands still have `OmniPreview start/stop` but now no `toggle`
When user runs either, it will behave as before if there is only 1 preview detected for the filetype

1 preview detected:

https://github.com/user-attachments/assets/cb6cb323-b755-4ff8-bac8-1e6c9f403591


If there are multiple previews detected, open UI. This applies to both `start` and `stop`

Multiple previews:

https://github.com/user-attachments/assets/232a6dc3-db1f-4dca-954d-490e3601ac63


@SylvanFranklin Let me know if you like the idea here. I would also test this out pointing to my fork/branch to see if you like it. I tested with all the plugins I use and tested builtins.
